### PR TITLE
INFRA-18260: Add extra logging for requests without ACL tokens

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -871,6 +871,7 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 			ACLDownPolicy:    stringVal(c.ACL.DownPolicy),
 			ACLDefaultPolicy: stringVal(c.ACL.DefaultPolicy),
 		},
+		LogACLInfo: boolVal(c.LogACLInfo),
 
 		ACLEnableKeyListPolicy:    boolVal(c.ACL.EnableKeyListPolicy),
 		ACLInitialManagementToken: stringVal(c.ACL.Tokens.InitialManagement),

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -192,6 +192,7 @@ type Config struct {
 	LicensePath                      *string             `mapstructure:"license_path" json:"license_path,omitempty"`
 	Limits                           Limits              `mapstructure:"limits" json:"-"`
 	Locality                         *Locality           `mapstructure:"locality" json:"-"`
+	LogACLInfo                       *bool               `mapstructure:"log_acl_info" json:"log_acl_info,omitempty"`
 	LogLevel                         *string             `mapstructure:"log_level" json:"log_level,omitempty"`
 	LogJSON                          *bool               `mapstructure:"log_json" json:"log_json,omitempty"`
 	LogFile                          *string             `mapstructure:"log_file" json:"log_file,omitempty"`

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -86,6 +86,8 @@ type RuntimeConfig struct {
 
 	ACLResolverSettings consul.ACLResolverSettings
 
+	LogACLInfo bool
+
 	// ACLEnableKeyListPolicy is used to opt-in to the "list" policy added to
 	// KV ACLs in Consul 1.0.
 	//

--- a/agent/http.go
+++ b/agent/http.go
@@ -541,6 +541,16 @@ func (s *HTTPHandlers) wrap(handler endpoint, methods []string) http.HandlerFunc
 			fmt.Fprint(resp, msg)
 		}
 
+		t := ""
+		s.parseToken(req, &t)
+		if s.agent.config.LogACLInfo && t == "" {
+			httpLogger.Info("No ACL token in request",
+				"url", logURL,
+				"user_agent", req.UserAgent(),
+				"remote_addr", req.RemoteAddr,
+			)
+		}
+
 		start := time.Now()
 		defer func() {
 			httpLogger.Debug("Request finished",


### PR DESCRIPTION
This adds the abilty to enable extra logging when `log_acl_info = true`. It is intended to log requests that _don't_ contain ACL info, to facilitate safer ACL enablement.

No logs are generated with the flag off / absent, or when there is a token present.

Logs look like this:
```
{
  "@level": "info",
  "@message": "No ACL token in request",
  "@module": "agent.http",
  "@timestamp": "2024-09-11T12:30:21.105571-04:00",
  "remote_addr": "127.0.0.1:56100",
  "url": "/v1/kv/",
  "user_agent": "curl/8.7.1"
}
```