### PR TITLE
INFRA-18260: Use parseTokenInternal to avoid setting default token

### DIFF
--- a/agent/http.go
+++ b/agent/http.go
@@ -542,7 +542,7 @@ func (s *HTTPHandlers) wrap(handler endpoint, methods []string) http.HandlerFunc
 		}
 
 		t := ""
-		s.parseToken(req, &t)
+		s.parseTokenInternal(req, &t)
 		if s.agent.config.LogACLInfo && t == "" {
 			httpLogger.Info("No ACL token in request",
 				"url", logURL,


### PR DESCRIPTION
### Description

`parseToken` sets the `default` token if none are included. My testing with `consul agent -dev` didn't have a default token, so this behavior was missed.

### Testing & Reproduction steps

config.hcl
```hcl
log_acl_info = true
log_json = true
acl {
  tokens {
    default = "asdf"
  }
}
```

Build and run against the above file: `consul agent -dev -config-file config.hcl`

With this patch, `curl localhost:8500/v1/kv/foo` correctly emits the log indicating a missing ACL token. Without the patch, no log is emitted.
